### PR TITLE
Add docker-compose configuration to repository.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+moh:
+    image: docker.io/avoxi/asterisk-moh:latest
+    read_only: true
+    container_name: asterisk-moh
+
+sounds-en:
+    image: docker.io/avoxi/asterisk-sounds-en:latest
+    read_only: true
+    container_name: asterisk-sounds-en
+
+spool:
+    image: centos:7
+    container_name: asterisk-spool
+    volumes:
+        - /var/spool/asterisk
+    command: su -c echo "Asterisk Spool"
+
+asterisk:
+    image: docker.io/avoxi/certified-asterisk:latest
+    container_name: ast01
+    hostname: ast01
+    extra_hosts:
+        - "ast01:127.0.0.1"
+    net: "none"
+    ports:
+        - "5060"
+        - "10000-20000"
+    volumes:
+        - ./etc-asterisk:/etc/asterisk
+    volumes_from:
+        - sounds-en
+        - moh
+        - spool


### PR DESCRIPTION
Add an initial docker-compose.yml. Still seems pretty fragile due to the
inherent nature of containers having a strong bias towards web frameworks.

When starting the Asterisk portion and mounting the volumes, things work fine
but you'll never have access to the console. You need to use a combination of
the `docker-compose up` to start the volumes, and the `docker-compose run` to
start up the Asterisk container.

Hopefully in the future things will be slight less web biased and more
generally microservices based.